### PR TITLE
Feature/appointment availability

### DIFF
--- a/src/main/java/com/ufmg/petclinic/controller/AppointmentController.java
+++ b/src/main/java/com/ufmg/petclinic/controller/AppointmentController.java
@@ -1,11 +1,13 @@
 package com.ufmg.petclinic.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.Optional;
 
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ufmg.petclinic.model.Appointment;
@@ -61,5 +64,14 @@ public class AppointmentController {
         Optional<Appointment> updated = service.updateAppointment(id, updatedAppointment);
         return updated.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/available-times")
+    public ResponseEntity<List<LocalDateTime>> getAvailableTimes(
+            @RequestParam UUID clinicId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        List<LocalDateTime> availableTimes = service.getAvailableTimes(clinicId, startDate, endDate);
+        return ResponseEntity.ok(availableTimes);
     }
 }

--- a/src/main/java/com/ufmg/petclinic/controller/AppointmentController.java
+++ b/src/main/java/com/ufmg/petclinic/controller/AppointmentController.java
@@ -33,9 +33,16 @@ public class AppointmentController {
     }
 
     @PostMapping
-    public ResponseEntity<Appointment> createAppointment(@RequestBody Appointment appointment) {
+    public ResponseEntity<?> createAppointment(@RequestBody Appointment appointment) {
+        boolean isAvailable = service.isTimeAvailable(appointment.getClinicId(), appointment.getAppointmentDateTime());
+    
+        if (!isAvailable) {
+            return ResponseEntity.status(409).body("Horário indisponível para agendamento.");
+        }
+    
         Appointment createdAppointment = service.createAppointment(appointment);
         return ResponseEntity.ok(createdAppointment);
+        
     }
 
      @GetMapping("/{id}")

--- a/src/main/java/com/ufmg/petclinic/repository/AppointmentRepository.java
+++ b/src/main/java/com/ufmg/petclinic/repository/AppointmentRepository.java
@@ -4,10 +4,12 @@ import com.ufmg.petclinic.model.Appointment;
 
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 public class AppointmentRepository {
@@ -40,6 +42,15 @@ public class AppointmentRepository {
             existingAppointment.setAppointmentDateTime(updatedAppointment.getAppointmentDateTime());
             return existingAppointment;
         });
+    }
+
+     public List<LocalDateTime> findUnavailableTimes(UUID clinicId, LocalDateTime startDate, LocalDateTime endDate) {
+        return appointments.stream()
+                .filter(a -> a.getClinicId().equals(clinicId))
+                .filter(a -> !a.getAppointmentDateTime().isBefore(startDate) &&
+                             !a.getAppointmentDateTime().isAfter(endDate))
+                .map(Appointment::getAppointmentDateTime)
+                .collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/com/ufmg/petclinic/service/AppointmentService.java
+++ b/src/main/java/com/ufmg/petclinic/service/AppointmentService.java
@@ -23,7 +23,17 @@ public class AppointmentService {
     }
 
     public Appointment createAppointment(Appointment appointment) {
+
         return repository.save(appointment);
+    }
+
+    public boolean isTimeAvailable(UUID clinicId, LocalDateTime appointmentDateTime) {
+        LocalDateTime startOfDay = appointmentDateTime.toLocalDate().atTime(8, 00);
+        LocalDateTime endOfDay = appointmentDateTime.toLocalDate().atTime(18, 00);
+
+        List<LocalDateTime> unavailableTimes = repository.findUnavailableTimes(clinicId, startOfDay, endOfDay);
+    
+        return !unavailableTimes.contains(appointmentDateTime);
     }
 
     public Optional<Appointment> getAppointmentById(UUID id) {

--- a/src/main/java/com/ufmg/petclinic/service/AppointmentService.java
+++ b/src/main/java/com/ufmg/petclinic/service/AppointmentService.java
@@ -1,8 +1,11 @@
 package com.ufmg.petclinic.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -37,5 +40,18 @@ public class AppointmentService {
 
     public Optional<Appointment> updateAppointment(UUID id, Appointment updatedAppointment) {
         return repository.update(id, updatedAppointment);
+    }
+
+    public List<LocalDateTime> getAvailableTimes(UUID clinicId, LocalDateTime startDate, LocalDateTime endDate) {
+        List<LocalDateTime> unavailableTimes = repository.findUnavailableTimes(clinicId, startDate, endDate);
+
+        // Supondo que os horários disponíveis sigam um padrao de intervalos de 1 hora entre startDate e endDate
+        List<LocalDateTime> allPossibleTimes = Stream.iterate(startDate, time -> time.plusHours(1))
+                .limit(startDate.until(endDate, java.time.temporal.ChronoUnit.HOURS) + 1)
+                .collect(Collectors.toList());
+
+        return allPossibleTimes.stream()
+                .filter(time -> !unavailableTimes.contains(time))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Add functionality to retrieve available times and check availability before scheduling

This pull request introduces two key features:

    A new functionality to retrieve available appointment times within a specified date range for a given clinic.
    A check to ensure that an appointment can only be scheduled if the selected time slot is available, preventing conflicts with existing appointments.

These enhancements improve the appointment scheduling process by ensuring that users can only book available slots